### PR TITLE
Switch to tls-certificates-operator

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,3 +6,5 @@ on:
 jobs:
   check:
     uses: ./.github/workflows/check.yml
+  deploy:
+    uses: ./.github/workflows/deploy.yml

--- a/main.tf
+++ b/main.tf
@@ -203,16 +203,14 @@ resource "juju_application" "traefik-public" {
 }
 
 
-# application:Vault
-# juju deploy --channel latest/stable --trust icey-vault-k8s vault
-resource "juju_application" "vault" {
-  name  = "vault"
+resource "juju_application" "certificate-authority" {
+  name  = "certificate-authority"
   trust = true
   model = juju_model.sunbeam.name
 
   charm {
-    name    = "icey-vault-k8s"
-    channel = "latest/stable"
+    name    = "tls-certificates-operator"
+    channel = "edge"
   }
 }
 
@@ -223,7 +221,7 @@ module "ovn" {
   scale       = 1
   relay       = true
   relay_scale = 1
-  vault       = juju_application.vault.name
+  ca          = juju_application.certificate-authority.name
 }
 
 
@@ -245,7 +243,7 @@ resource "juju_integration" "ovn-central-to-neutron" {
 
 
 # juju integrate neutron vault
-resource "juju_integration" "neutron-to-vault" {
+resource "juju_integration" "neutron-to-ca" {
   model = juju_model.sunbeam.name
 
   application {
@@ -254,8 +252,8 @@ resource "juju_integration" "neutron-to-vault" {
   }
 
   application {
-    name     = juju_application.vault.name
-    endpoint = "insecure-certificates"
+    name     = juju_application.certificate-authority.name
+    endpoint = "certificates"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -212,6 +212,11 @@ resource "juju_application" "certificate-authority" {
     name    = "tls-certificates-operator"
     channel = "edge"
   }
+
+  config = {
+    generate-self-signed-certificates = true
+    ca-common-name                    = "internal-ca"
+  }
 }
 
 module "ovn" {

--- a/modules/ovn/main.tf
+++ b/modules/ovn/main.tf
@@ -69,7 +69,7 @@ resource "juju_integration" "ovn-central-to-ovn-relay" {
   }
 }
 
-resource "juju_integration" "ovn-central-to-vault" {
+resource "juju_integration" "ovn-central-to-ca" {
   model = var.model
 
   application {
@@ -78,12 +78,12 @@ resource "juju_integration" "ovn-central-to-vault" {
   }
 
   application {
-    name     = var.vault
-    endpoint = "insecure-certificates"
+    name     = var.ca
+    endpoint = "certificates"
   }
 }
 
-resource "juju_integration" "ovn-relay-to-vault" {
+resource "juju_integration" "ovn-relay-to-ca" {
   count = var.relay != "" ? 1 : 0
   model = var.model
 
@@ -93,8 +93,8 @@ resource "juju_integration" "ovn-relay-to-vault" {
   }
 
   application {
-    name     = var.vault
-    endpoint = "insecure-certificates"
+    name     = var.ca
+    endpoint = "certificates"
   }
 }
 

--- a/modules/ovn/variables.tf
+++ b/modules/ovn/variables.tf
@@ -42,8 +42,8 @@ variable "relay_scale" {
   default     = 1
 }
 
-variable "vault" {
-  description = "Application name of Vault operator"
+variable "ca" {
+  description = "Application name of certificate authority operator"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Use the Snake Oil tls-certificates operator by default rather than vault to avoid key management complexities.