### PR TITLE
tls-certificates-operator: use jammy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -211,6 +211,7 @@ resource "juju_application" "certificate-authority" {
   charm {
     name    = "tls-certificates-operator"
     channel = "edge"
+    series  = "jammy"
   }
 
   config = {


### PR DESCRIPTION
Ensure that jammy is use as the base for the tls-certificates-operator; the bundled virtualenv is not compatible with focal.