### PR TITLE
Add horizon charm

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,13 @@ module "neutron-mysql" {
   channel = var.mysql_channel
 }
 
+module "horizon-mysql" {
+  source  = "./modules/mysql"
+  model   = juju_model.sunbeam.name
+  name    = "horizon-mysql"
+  channel = var.mysql_channel
+}
+
 module "rabbitmq" {
   source  = "./modules/rabbitmq"
   model   = juju_model.sunbeam.name
@@ -113,6 +120,18 @@ module "nova" {
   ingress-internal = juju_application.traefik-internal.name
   ingress-public   = juju_application.traefik-public.name
   scale            = 1
+}
+
+module "horizon" {
+  source               = "./modules/openstack-api"
+  charm                = "horizon-k8s"
+  name                 = "horizon"
+  model                = juju_model.sunbeam.name
+  channel              = var.openstack_channel
+  mysql                = module.horizon-mysql.name
+  keystone-credentials = module.keystone.name
+  ingress-internal     = juju_application.traefik-internal.name
+  ingress-public       = juju_application.traefik-public.name
 }
 
 # TODO: specific module for nova?

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -85,6 +85,21 @@ resource "juju_integration" "keystone-to-service" {
   }
 }
 
+resource "juju_integration" "service-to-keystone" {
+  for_each = var.keystone-credentials == "" ? {} : { target = var.keystone-credentials }
+  model    = var.model
+
+  application {
+    name     = each.value
+    endpoint = "identity-credentials"
+  }
+
+  application {
+    name     = juju_application.service.name
+    endpoint = "cloud-credentials"
+  }
+}
+
 # juju integrate traefik-public glance
 resource "juju_integration" "traefik-public-to-service" {
   model = var.model

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -57,6 +57,12 @@ variable "keystone" {
   default     = ""
 }
 
+variable "keystone-credentials" {
+  description = "Keystone operator to integrate with"
+  type        = string
+  default     = ""
+}
+
 variable "ingress-internal" {
   description = "Ingress operator to integrate with for internal endpoints"
   type        = string


### PR DESCRIPTION
Add horizon deployment and cloud-credentials compatibility needed by horizon.

Cloud-credentials controlled through `keystone-credentials` variable in openstack-api module.

Depends-On: https://review.opendev.org/c/openstack/charm-horizon-k8s/+/876734
Depends-On: https://review.opendev.org/c/openstack/charm-horizon-k8s/+/876715