### PR TITLE
Upgrade juju's version to 3.1/stable in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
-          juju-channel: 3.0/candidate
+          juju-channel: 3.1/stable
           microk8s-addons: hostpath-storage dns rbac metallb:10.64.140.40-10.64.140.49
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Juju 3.1 is mandatory for secrets use.