### PR TITLE
mysql: use 8.0/stable channel

### DIFF
--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -21,7 +21,7 @@ variable "name" {
 
 variable "channel" {
   description = "MySQL K8S operator channel"
-  default     = "edge"
+  default     = "8.0/stable"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "openstack_channel" {
 
 variable "mysql_channel" {
   description = "Operator channel for MySQL deployment"
-  default     = "edge"
+  default     = "8.0/stable"
 }
 
 variable "rabbitmq_channel" {


### PR DESCRIPTION
'edge' disappeared; switch to using a more stable and hopefully supported channel for mysql.