### PR TITLE
Add ceph-osd-replication-count config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,9 @@ module "glance" {
   ingress-public   = juju_application.traefik.name
   # Cannot scale at the moment
   scale = 1 # var.os-api-scale
+  resource-configs = {
+    ceph-osd-replication-count = var.ceph_osd_replication_count
+  }
 }
 
 module "keystone" {
@@ -274,6 +277,9 @@ module "cinder-ceph" {
   ingress-internal = ""
   ingress-public   = ""
   scale            = var.ha-scale
+  resource-configs = {
+    ceph-osd-replication-count = var.ceph_osd_replication_count
+  }
 }
 
 # juju integrate cinder cinder-ceph

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -25,9 +25,9 @@ terraform {
 }
 
 resource "juju_application" "service" {
-  name  = var.name
-  trust = true
-  model = var.model
+  name   = var.name
+  trust  = true
+  model  = var.model
 
   charm {
     name    = var.charm
@@ -35,7 +35,9 @@ resource "juju_application" "service" {
     series  = "jammy"
   }
 
-  units = var.scale
+  config = var.resource-configs
+
+  units  = var.scale
 }
 
 resource "juju_integration" "service-to-mysql" {

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -72,3 +72,9 @@ variable "ingress-public" {
   description = "Ingress operator to integrate with for public endpoints"
   type        = string
 }
+
+variable "resource-configs" {
+  description = "Configs to set for all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,11 @@ variable "ceph_offer_url" {
   default     = "admin/controller.microceph"
 }
 
+variable "ceph_osd_replication_count" {
+  description = "Ceph OSd replication count to set on glance/cinder"
+  default     = 1
+}
+
 variable "ha-scale" {
   description = "Scale of traditional HA deployments"
   # Need better name, because 1 is not HA, needs to encompass services like MySQL, RabbitMQ and OVN


### PR DESCRIPTION
Make config section as variable for module
openstack-api. Add ceph-osd-replication-count
as variable with 1 as default. Update glance
and cinder-ceph config option with
ceph-osd-replication-count.