### PR TITLE
rabbitmq: use 3.9 track

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "mysql_channel" {
 
 variable "rabbitmq_channel" {
   description = "Operator channel for RabbitMQ deployment"
-  default     = "3.11/beta"
+  default     = "3.9/beta"
 }
 
 variable "ovn_channel" {


### PR DESCRIPTION
The 3.9 track is now using a supportable ROCK from Ubuntu; switch to using this track over 3.11 which will be closed.