### PR TITLE
Drop trust for os-api and ovn-central

### DIFF
--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -26,7 +26,6 @@ terraform {
 
 resource "juju_application" "service" {
   name  = var.name
-  trust = true
   model = var.model
 
   charm {

--- a/modules/ovn/main.tf
+++ b/modules/ovn/main.tf
@@ -26,7 +26,6 @@ terraform {
 
 resource "juju_application" "ovn-central" {
   name  = "ovn-central"
-  trust = true
   model = var.model
 
   charm {


### PR DESCRIPTION
Opening svc port is now implemented through 'open-port', trust is not required anymore