### PR TITLE
Disable serialize image pulls on CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,19 @@ jobs:
         with:
           provider: microk8s
           channel: 1.26-strict/stable
-          juju-channel: 3.1/stable
+          juju-channel: 3.2/stable
           microk8s-addons: hostpath-storage dns rbac metallb:10.64.140.40-10.64.140.49
+      - name: Configure kubelet arguments
+        run: |
+          echo "--serialize-image-pulls=false" | sudo tee -a /var/snap/microk8s/current/args/kubelet
+          sudo microk8s stop
+          sudo microk8s start
+          sudo microk8s status --wait-ready --timeout 300
+          sudo microk8s.kubectl get -n controller-$CONTROLLER_NAME pod/controller-0
+          sudo microk8s.kubectl wait --for=jsonpath='{.status.phase}'=Running -n controller-$CONTROLLER_NAME --timeout 5m pod/controller-0
+          while ! juju show-controller 2> /dev/null; do sleep 10; done
+          address=$(juju show-controller --format json | jq -r .\"$CONTROLLER_NAME\"'.details."api-endpoints" | first')
+          curl -k -s --connect-timeout 300 https://$address
       - name: Install dependencies
         run: |
           sudo snap install --classic terraform
@@ -25,9 +36,21 @@ jobs:
       - name: Apply terraform
         run: |
           terraform init
-          terraform apply -auto-approve
+          terraform apply -auto-approve \
+            -var "ovn-channel=23.03/edge" \
+            -var "openstack-channel=2023.1/edge"
+      - name: Wait for deployment
+        run: |
           juju model-config -m openstack automatically-retry-hooks=true
           juju-wait -vw -m openstack -t 3600 -x cinder-ceph -r 3
+      - name: Get pods logs
+        if: always()
+        run: |
+          for pod in $(kubectl get pods -n openstack -o=jsonpath='{.items[*].metadata.name}');
+          do
+            echo Collecting logs: $pod
+            kubectl logs -n openstack --all-containers $pod
+          done
       - name: Collect juju status
         if: always()
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,8 @@ jobs:
           terraform init
           terraform apply -auto-approve \
             -var "ovn-channel=23.03/edge" \
-            -var "openstack-channel=2023.1/edge"
+            -var "openstack-channel=2023.1/edge" \
+            -var "mysql-constraints=mem=768M"
       - name: Wait for deployment
         run: |
           juju model-config -m openstack automatically-retry-hooks=true

--- a/main.tf
+++ b/main.tf
@@ -48,13 +48,14 @@ resource "juju_model" "sunbeam" {
 }
 
 module "mysql" {
-  source     = "./modules/mysql"
-  model      = juju_model.sunbeam.name
-  name       = "mysql"
-  channel    = var.mysql-channel
-  scale      = var.ha-scale
-  many-mysql = var.many-mysql
-  services   = local.services-with-mysql
+  source      = "./modules/mysql"
+  model       = juju_model.sunbeam.name
+  name        = "mysql"
+  channel     = var.mysql-channel
+  scale       = var.ha-scale
+  many-mysql  = var.many-mysql
+  services    = local.services-with-mysql
+  constraints = var.mysql-constraints
 }
 
 module "rabbitmq" {

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "mysql-channel" {
   default     = "8.0/candidate"
 }
 
+variable "mysql-constraints" {
+  description = "Constraints for MySQL K8S operator"
+  default     = "mem=2048M"
+  type        = string
+}
+
 variable "mysql-router-channel" {
   description = "Operator channel for MySQL router deployment"
   default     = "8.0/candidate"


### PR DESCRIPTION
Disabling serialize image pulls can help reduce the CI duration.