### PR TITLE
Pass top level channel configuration to cinder-ceph

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -283,6 +283,7 @@ module "cinder-ceph" {
   resource-configs = {
     ceph-osd-replication-count = var.ceph-osd-replication-count
   }
+  mysql-router-channel = var.mysql-router-channel
 }
 
 # juju integrate cinder cinder-ceph


### PR DESCRIPTION
Fixes an issue where the mysql-router channel used for this charm was pinned to 8.0/edge.

(cherry picked from commit e3782959829fdcdbf04b942d7cee448d3944aed4)