### PR TITLE
Add terraform plan for heat

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -319,3 +319,60 @@ resource "juju_offer" "ca-offer" {
   application_name = juju_application.certificate-authority.name
   endpoint         = "certificates"
 }
+
+module "mysql-heat" {
+  count      = var.enable-heat ? (var.many-mysql ? 1 : 0) : 0
+  source     = "./modules/mysql"
+  model      = juju_model.sunbeam.name
+  name       = "mysql"
+  channel    = var.mysql-channel
+  scale      = var.ha-scale
+  many-mysql = var.many-mysql
+  services   = ["heat"]
+}
+
+module "heat" {
+  count                = var.enable-heat ? 1 : 0
+  source               = "./modules/openstack-api"
+  charm                = "heat-k8s"
+  name                 = "heat"
+  model                = juju_model.sunbeam.name
+  channel              = var.openstack-channel
+  rabbitmq             = module.rabbitmq.name
+  mysql                = var.many-mysql ? module.mysql-heat[0].name["heat"] : "mysql"
+  keystone             = module.keystone.name
+  ingress-internal     = juju_application.traefik.name
+  ingress-public       = juju_application.traefik.name
+  scale                = var.os-api-scale
+  mysql-router-channel = var.mysql-router-channel
+}
+
+module "mysql-heat-cfn" {
+  count      = var.enable-heat ? (var.many-mysql ? 1 : 0) : 0
+  source     = "./modules/mysql"
+  model      = juju_model.sunbeam.name
+  name       = "mysql"
+  channel    = var.mysql-channel
+  scale      = var.ha-scale
+  many-mysql = var.many-mysql
+  services   = ["heat"]
+}
+
+module "heat-cfn" {
+  count                = var.enable-heat ? 1 : 0
+  source               = "./modules/openstack-api"
+  charm                = "heat-k8s"
+  name                 = "heat-cfn"
+  model                = juju_model.sunbeam.name
+  channel              = var.openstack-channel
+  rabbitmq             = module.rabbitmq.name
+  mysql                = var.many-mysql ? module.mysql-heat-cfn[0].name["heat"] : "mysql"
+  keystone             = module.keystone.name
+  ingress-internal     = juju_application.traefik.name
+  ingress-public       = juju_application.traefik.name
+  scale                = var.os-api-scale
+  mysql-router-channel = var.mysql-router-channel
+  resource-configs = {
+    api_service = "heat-api-cfn"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -337,7 +337,7 @@ module "heat" {
   charm                = "heat-k8s"
   name                 = "heat"
   model                = juju_model.sunbeam.name
-  channel              = var.openstack-channel
+  channel              = var.heat-channel
   rabbitmq             = module.rabbitmq.name
   mysql                = var.many-mysql ? module.mysql-heat[0].name["heat"] : "mysql"
   keystone             = module.keystone.name
@@ -347,26 +347,15 @@ module "heat" {
   mysql-router-channel = var.mysql-router-channel
 }
 
-module "mysql-heat-cfn" {
-  count      = var.enable-heat ? (var.many-mysql ? 1 : 0) : 0
-  source     = "./modules/mysql"
-  model      = juju_model.sunbeam.name
-  name       = "mysql"
-  channel    = var.mysql-channel
-  scale      = var.ha-scale
-  many-mysql = var.many-mysql
-  services   = ["heat"]
-}
-
 module "heat-cfn" {
   count                = var.enable-heat ? 1 : 0
   source               = "./modules/openstack-api"
   charm                = "heat-k8s"
   name                 = "heat-cfn"
   model                = juju_model.sunbeam.name
-  channel              = var.openstack-channel
+  channel              = var.heat-channel
   rabbitmq             = module.rabbitmq.name
-  mysql                = var.many-mysql ? module.mysql-heat-cfn[0].name["heat"] : "mysql"
+  mysql                = var.many-mysql ? module.mysql-heat[0].name["heat"] : "mysql"
   keystone             = module.keystone.name
   ingress-internal     = juju_application.traefik.name
   ingress-public       = juju_application.traefik.name

--- a/variables.tf
+++ b/variables.tf
@@ -100,3 +100,9 @@ variable "enable-heat" {
   description = "Enable OpenStack Heat service"
   default     = false
 }
+
+# Temporary channel for heat until 2023.1/stable is released.
+variable "heat-channel" {
+  description = "Operator channel for OpenStack Heat deployment"
+  default     = "latest/edge"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -95,3 +95,8 @@ variable "many-mysql" {
   description = "Enabling this will switch architecture from one global mysql to one per service"
   default     = false
 }
+
+variable "enable-heat" {
+  description = "Enable OpenStack Heat service"
+  default     = false
+}


### PR DESCRIPTION
Add terraform plan for heat service.
Add enable-heat variable to decide on deploy or
destroy heat application.