### PR TITLE
Add identity-ops integration for heat

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           provider: microk8s
           channel: 1.26-strict/stable
-          juju-channel: 3.1/stable
+          juju-channel: 3.2/stable
+          bootstrap-options: --agent-version=3.2.0
           microk8s-addons: hostpath-storage dns rbac metallb:10.64.140.40-10.64.140.49
       - name: Install dependencies
         run: |

--- a/main.tf
+++ b/main.tf
@@ -341,6 +341,7 @@ module "heat" {
   rabbitmq             = module.rabbitmq.name
   mysql                = var.many-mysql ? module.mysql-heat[0].name["heat"] : "mysql"
   keystone             = module.keystone.name
+  keystone-ops         = module.keystone.name
   ingress-internal     = juju_application.traefik.name
   ingress-public       = juju_application.traefik.name
   scale                = var.os-api-scale
@@ -357,6 +358,7 @@ module "heat-cfn" {
   rabbitmq             = module.rabbitmq.name
   mysql                = var.many-mysql ? module.mysql-heat[0].name["heat"] : "mysql"
   keystone             = module.keystone.name
+  keystone-ops         = module.keystone.name
   ingress-internal     = juju_application.traefik.name
   ingress-public       = juju_application.traefik.name
   scale                = var.os-api-scale

--- a/modules/openstack-api/main.tf
+++ b/modules/openstack-api/main.tf
@@ -129,6 +129,21 @@ resource "juju_integration" "service-to-keystone" {
   }
 }
 
+resource "juju_integration" "service-to-keystone-ops" {
+  for_each = var.keystone-ops == "" ? {} : { target = var.keystone-ops }
+  model    = var.model
+
+  application {
+    name     = each.value
+    endpoint = "identity-ops"
+  }
+
+  application {
+    name     = juju_application.service.name
+    endpoint = "identity-ops"
+  }
+}
+
 # juju integrate traefik-public glance
 resource "juju_integration" "traefik-public-to-service" {
   for_each = var.ingress-public == "" ? {} : { target = var.ingress-public }

--- a/modules/openstack-api/variables.tf
+++ b/modules/openstack-api/variables.tf
@@ -69,6 +69,12 @@ variable "keystone-credentials" {
   default     = ""
 }
 
+variable "keystone-ops" {
+  description = "Keystone operator to integrate with"
+  type        = string
+  default     = ""
+}
+
 variable "ingress-internal" {
   description = "Ingress operator to integrate with for internal endpoints"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -104,5 +104,5 @@ variable "enable-heat" {
 # Temporary channel for heat until 2023.1/stable is released.
 variable "heat-channel" {
   description = "Operator channel for OpenStack Heat deployment"
-  default     = "latest/edge"
+  default     = "2023.1/edge"
 }


### PR DESCRIPTION
Add identity-ops integration in openstack-api module.
Enable identity-ops integration for heat and heat-cfn.
Change default channel for heat to 2023.1/edge.